### PR TITLE
Update to scalacheck [1.15.1 -> 1.15.2]. Fix to Errors in errors.scala

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,7 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.1"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.compiler.SourcePosition
-import net.logstash.logback.encoder.org.apache.commons.lang.exception.ExceptionUtils
+import net.logstash.logback.encoder.org.apache.commons.lang3.exception.ExceptionUtils
 
 object errors {
 
@@ -107,7 +107,7 @@ object errors {
       interpreterErrors: Vector[InterpreterError],
       errors: Vector[Throwable]
   ) extends InterpreterError(
-        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getFullStackTrace).mkString}"
+        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getStackTrace).mkString}"
       )
 
   // Current implementation of SpaceMatcher (extractDataCandidates) causes unmatched comms


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Updates scalacheck from 1.15.1 -> 1.15.2
Fixes errors in rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala by updating deprecated code. 


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
